### PR TITLE
Update to custom repo server build to match OpenShift GitOps version

### DIFF
--- a/setup/ocp/argocd-instance/argocd-instance.yaml
+++ b/setup/ocp/argocd-instance/argocd-instance.yaml
@@ -437,7 +437,7 @@ spec:
   #   scopes: '[groups]'
   repo:
     image: quay.io/benswinneyau/openshift-gitops-repo-server
-    version: latest
+    version: v1.4.1-1
     resources:
       limits:
         cpu: '1'


### PR DESCRIPTION
Latest OpenShift GitOps Repo Server version is now 1.4.1-1. Update image tag to reference correct image.